### PR TITLE
Feat: In house 1.10 development

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -1,6 +1,6 @@
-name: 'Deploy to Vercel Action'
-description: 'Deploy your project to Vercel using GitHub Actions. Supports PR previews and GitHub deployments.'
-author: 'BetaHuhn'
+name: "Deploy to Vercel Action"
+description: "Deploy your project to Vercel using GitHub Actions. Supports PR previews and GitHub deployments."
+author: "BetaHuhn"
 
 inputs:
   GITHUB_TOKEN:
@@ -83,25 +83,31 @@ inputs:
     description: |
       Used to skip the build cache.
     required: false
+  PER_BRANCH_CONFIG:
+    description: |
+      A dictionary of aliases to be assigned to the deployment, passed as a JSON string.
+      Will set the ALIAS_DOMAINS and PRODUCTION configurations on a per-branch basis.
+      Should be in the format of {"${BRANCH}": {"aliases": [...], "production": false } }.
+    required: false
 
 outputs:
   PREVIEW_URL:
-    description: 'Main deployment preview URL.'
+    description: "Main deployment preview URL."
   DEPLOYMENT_URLS:
-    description: 'All assigned deployment URLs.'
+    description: "All assigned deployment URLs."
   DEPLOYMENT_CREATED:
-    description: 'True if a Vercel deployment was created.'
+    description: "True if a Vercel deployment was created."
   COMMENT_CREATED:
-    description: 'True if a comment was created on the PR or commit.'
+    description: "True if a comment was created on the PR or commit."
   DEPLOYMENT_INSPECTOR_URL:
-    description: 'Main deployment inspection url.'
+    description: "Main deployment inspection url."
   DEPLOYMENT_UNIQUE_URL:
-    description: 'The unique deployment url on Vercel'
+    description: "The unique deployment url on Vercel"
 
 runs:
-  using: 'node16'
-  main: 'dist/index.js'
+  using: "node16"
+  main: "dist/index.js"
 
 branding:
-  icon: 'triangle'
-  color: 'white'
+  icon: "triangle"
+  color: "white"

--- a/dist/index.js
+++ b/dist/index.js
@@ -18509,162 +18509,202 @@ function wrappy (fn, cb) {
 /***/ 9439:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
-const core = __nccwpck_require__(7733)
-const github = __nccwpck_require__(5554)
-const parser = __nccwpck_require__(3687)
-__nccwpck_require__(7901).config()
+const core = __nccwpck_require__(7733);
+const github = __nccwpck_require__(5554);
+const parser = __nccwpck_require__(3687);
+(__nccwpck_require__(7901).config)();
 
-const IS_PR = [ 'pull_request', 'pull_request_target' ].includes(github.context.eventName)
+const IS_PR = ["pull_request", "pull_request_target"].includes(
+  github.context.eventName
+);
 
 const context = {
-	GITHUB_TOKEN: parser.getInput({
-		key: [ 'GH_PAT', 'GITHUB_TOKEN' ],
-		required: true
-	}),
-	VERCEL_TOKEN: parser.getInput({
-		key: 'VERCEL_TOKEN',
-		required: true
-	}),
-	VERCEL_ORG_ID: parser.getInput({
-		key: 'VERCEL_ORG_ID',
-		required: true
-	}),
-	VERCEL_PROJECT_ID: parser.getInput({
-		key: 'VERCEL_PROJECT_ID',
-		required: true
-	}),
-	PRODUCTION: parser.getInput({
-		key: 'PRODUCTION',
-		type: 'boolean',
-		default: !IS_PR
-	}),
-	GITHUB_DEPLOYMENT: parser.getInput({
-		key: 'GITHUB_DEPLOYMENT',
-		type: 'boolean',
-		default: true
-	}),
-	CREATE_COMMENT: parser.getInput({
-		key: 'CREATE_COMMENT',
-		type: 'boolean',
-		default: true
-	}),
-	DELETE_EXISTING_COMMENT: parser.getInput({
-		key: 'DELETE_EXISTING_COMMENT',
-		type: 'boolean',
-		default: true
-	}),
-	ATTACH_COMMIT_METADATA: parser.getInput({
-		key: 'ATTACH_COMMIT_METADATA',
-		type: 'boolean',
-		default: true
-	}),
-	DEPLOY_PR_FROM_FORK: parser.getInput({
-		key: 'DEPLOY_PR_FROM_FORK',
-		type: 'boolean',
-		default: false
-	}),
-	PR_LABELS: parser.getInput({
-		key: 'PR_LABELS',
-		default: [ 'deployed' ],
-		type: 'array',
-		disableable: true
-	}),
-	ALIAS_DOMAINS: parser.getInput({
-		key: 'ALIAS_DOMAINS',
-		type: 'array',
-		disableable: true
-	}),
-	PR_PREVIEW_DOMAIN: parser.getInput({
-		key: 'PR_PREVIEW_DOMAIN'
-	}),
-	VERCEL_SCOPE: parser.getInput({
-		key: 'VERCEL_SCOPE'
-	}),
-	GITHUB_REPOSITORY: parser.getInput({
-		key: 'GITHUB_REPOSITORY',
-		required: true
-	}),
-	GITHUB_DEPLOYMENT_ENV: parser.getInput({
-		key: 'GITHUB_DEPLOYMENT_ENV'
-	}),
-	TRIM_COMMIT_MESSAGE: parser.getInput({
-		key: 'TRIM_COMMIT_MESSAGE',
-		type: 'boolean',
-		default: false
-	}),
-	WORKING_DIRECTORY: parser.getInput({
-		key: 'WORKING_DIRECTORY'
-	}),
-	BUILD_ENV: parser.getInput({
-		key: 'BUILD_ENV',
-		type: 'array'
-	}),
-	PREBUILT: parser.getInput({
-		key: 'PREBUILT',
-		type: 'boolean',
-		default: false
-	}),
-	RUNNING_LOCAL: process.env.RUNNING_LOCAL === 'true',
-	FORCE: parser.getInput({
-		key: 'FORCE',
-		type: 'boolean',
-		default: false
-	})
-}
+  GITHUB_TOKEN: parser.getInput({
+    key: ["GH_PAT", "GITHUB_TOKEN"],
+    required: true,
+  }),
+  VERCEL_TOKEN: parser.getInput({
+    key: "VERCEL_TOKEN",
+    required: true,
+  }),
+  VERCEL_ORG_ID: parser.getInput({
+    key: "VERCEL_ORG_ID",
+    required: true,
+  }),
+  VERCEL_PROJECT_ID: parser.getInput({
+    key: "VERCEL_PROJECT_ID",
+    required: true,
+  }),
+  PRODUCTION: parser.getInput({
+    key: "PRODUCTION",
+    type: "boolean",
+    default: !IS_PR,
+  }),
+  GITHUB_DEPLOYMENT: parser.getInput({
+    key: "GITHUB_DEPLOYMENT",
+    type: "boolean",
+    default: true,
+  }),
+  CREATE_COMMENT: parser.getInput({
+    key: "CREATE_COMMENT",
+    type: "boolean",
+    default: true,
+  }),
+  DELETE_EXISTING_COMMENT: parser.getInput({
+    key: "DELETE_EXISTING_COMMENT",
+    type: "boolean",
+    default: true,
+  }),
+  ATTACH_COMMIT_METADATA: parser.getInput({
+    key: "ATTACH_COMMIT_METADATA",
+    type: "boolean",
+    default: true,
+  }),
+  DEPLOY_PR_FROM_FORK: parser.getInput({
+    key: "DEPLOY_PR_FROM_FORK",
+    type: "boolean",
+    default: false,
+  }),
+  PR_LABELS: parser.getInput({
+    key: "PR_LABELS",
+    default: ["deployed"],
+    type: "array",
+    disableable: true,
+  }),
+  ALIAS_DOMAINS: parser.getInput({
+    key: "ALIAS_DOMAINS",
+    type: "array",
+    disableable: true,
+  }),
+  PR_PREVIEW_DOMAIN: parser.getInput({
+    key: "PR_PREVIEW_DOMAIN",
+  }),
+  VERCEL_SCOPE: parser.getInput({
+    key: "VERCEL_SCOPE",
+  }),
+  GITHUB_REPOSITORY: parser.getInput({
+    key: "GITHUB_REPOSITORY",
+    required: true,
+  }),
+  GITHUB_DEPLOYMENT_ENV: parser.getInput({
+    key: "GITHUB_DEPLOYMENT_ENV",
+  }),
+  TRIM_COMMIT_MESSAGE: parser.getInput({
+    key: "TRIM_COMMIT_MESSAGE",
+    type: "boolean",
+    default: false,
+  }),
+  WORKING_DIRECTORY: parser.getInput({
+    key: "WORKING_DIRECTORY",
+  }),
+  BUILD_ENV: parser.getInput({
+    key: "BUILD_ENV",
+    type: "array",
+  }),
+  PREBUILT: parser.getInput({
+    key: "PREBUILT",
+    type: "boolean",
+    default: false,
+  }),
+  RUNNING_LOCAL: process.env.RUNNING_LOCAL === "true",
+  FORCE: parser.getInput({
+    key: "FORCE",
+    type: "boolean",
+    default: false,
+  }),
+
+  // Github actions do not support dictionaries. We have pass json strings
+  // https://github.com/argoproj/argo-workflows/issues/2077
+  PER_BRANCH_CONFIG: parser.getInput({
+    key: "PER_BRANCH_CONFIG",
+  }),
+};
 
 const setDynamicVars = () => {
-	context.USER = context.GITHUB_REPOSITORY.split('/')[0]
-	context.REPOSITORY = context.GITHUB_REPOSITORY.split('/')[1]
+  context.USER = context.GITHUB_REPOSITORY.split("/")[0];
+  context.REPOSITORY = context.GITHUB_REPOSITORY.split("/")[1];
 
-	// If running the action locally, use env vars instead of github.context
-	if (context.RUNNING_LOCAL) {
-		context.SHA = process.env.SHA || 'XXXXXXX'
-		context.IS_PR = process.env.IS_PR === 'true' || false
-		context.PR_NUMBER = process.env.PR_NUMBER || undefined
-		context.REF = process.env.REF || 'refs/heads/master'
-		context.BRANCH = process.env.BRANCH || 'master'
-		context.PRODUCTION = process.env.PRODUCTION === 'true' || !context.IS_PR
-		context.LOG_URL = process.env.LOG_URL || `https://github.com/${ context.USER }/${ context.REPOSITORY }`
-		context.ACTOR = process.env.ACTOR || context.USER
-		context.IS_FORK = process.env.IS_FORK === 'true' || false
-		context.TRIM_COMMIT_MESSAGE = process.env.TRIM_COMMIT_MESSAGE === 'true' || false
+  // If running the action locally, use env vars instead of github.context
+  if (context.RUNNING_LOCAL) {
+    context.SHA = process.env.SHA || "XXXXXXX";
+    context.IS_PR = process.env.IS_PR === "true" || false;
+    context.PR_NUMBER = process.env.PR_NUMBER || undefined;
+    context.REF = process.env.REF || "refs/heads/master";
+    context.BRANCH = process.env.BRANCH || "master";
+    context.PRODUCTION = process.env.PRODUCTION === "true" || !context.IS_PR;
+    context.LOG_URL =
+      process.env.LOG_URL ||
+      `https://github.com/${context.USER}/${context.REPOSITORY}`;
+    context.ACTOR = process.env.ACTOR || context.USER;
+    context.IS_FORK = process.env.IS_FORK === "true" || false;
+    context.TRIM_COMMIT_MESSAGE =
+      process.env.TRIM_COMMIT_MESSAGE === "true" || false;
 
-		return
-	}
+    return;
+  }
 
-	context.IS_PR = IS_PR
-	context.LOG_URL = `https://github.com/${ context.USER }/${ context.REPOSITORY }/actions/runs/${ process.env.GITHUB_RUN_ID }`
+  context.IS_PR = IS_PR;
+  context.LOG_URL = `https://github.com/${context.USER}/${context.REPOSITORY}/actions/runs/${process.env.GITHUB_RUN_ID}`;
 
-	// Use different values depending on if the Action was triggered by a PR
-	if (context.IS_PR) {
-		context.PR_NUMBER = github.context.payload.number
-		context.ACTOR = github.context.payload.pull_request.user.login
-		context.REF = github.context.payload.pull_request.head.ref
-		context.SHA = github.context.payload.pull_request.head.sha
-		context.BRANCH = github.context.payload.pull_request.head.ref
-		context.IS_FORK = github.context.payload.pull_request.head.repo.full_name !== context.GITHUB_REPOSITORY
-	} else {
-		context.ACTOR = github.context.actor
-		context.REF = github.context.ref
-		context.SHA = github.context.sha
-		context.BRANCH = github.context.ref.substr(11)
-	}
-}
+  // Use different values depending on if the Action was triggered by a PR
+  if (context.IS_PR) {
+    context.PR_NUMBER = github.context.payload.number;
+    context.ACTOR = github.context.payload.pull_request.user.login;
+    context.REF = github.context.payload.pull_request.head.ref;
+    context.SHA = github.context.payload.pull_request.head.sha;
+    context.BRANCH = github.context.payload.pull_request.head.ref;
+    context.IS_FORK =
+      github.context.payload.pull_request.head.repo.full_name !==
+      context.GITHUB_REPOSITORY;
+  } else {
+    context.ACTOR = github.context.actor;
+    context.REF = github.context.ref;
+    context.SHA = github.context.sha;
+    context.BRANCH = github.context.ref.substr(11);
+  }
+};
 
-setDynamicVars()
+const parseJsonAliasesDict = () => {
+  try {
+    return JSON.parse(context.PER_BRANCH_CONFIG);
+  } catch (err) {
+    core.setFailed("PER_BRANCH_CONFIG is not a valid JSON string");
+    throw err;
+  }
+};
 
-core.setSecret(context.GITHUB_TOKEN)
-core.setSecret(context.VERCEL_TOKEN)
+const usePerBranchConfig = () => {
+  if (context.PER_BRANCH_CONFIG) {
+    /**
+     * @typedef {{aliases: string[], production: boolean}} BranchEntry
+     */
+    /** @type Object.<string, BranchEntry> */
+    const dict = parseJsonAliasesDict();
+    core.info(`Using per-branch config for branch ${context.BRANCH}`);
 
-core.debug(
-	JSON.stringify(
-		context,
-		null,
-		2
-	)
-)
+    const branchEntry = dict[context.BRANCH];
+    if (!branchEntry) {
+      core.info(`No config found for branch ${context.BRANCH}`);
+    }
 
-module.exports = context
+    core.info(branchEntry);
+    context.ALIAS_DOMAINS = branchEntry.aliases;
+    context.PRODUCTION = branchEntry.production;
+  } else {
+    // using this to know if this is working
+    core.warn("No PER_BRANCH_CONFIG found");
+  }
+};
+
+setDynamicVars();
+usePerBranchConfig();
+
+core.setSecret(context.GITHUB_TOKEN);
+core.setSecret(context.VERCEL_TOKEN);
+
+core.debug(JSON.stringify(context, null, 2));
+
+module.exports = context;
 
 
 /***/ }),

--- a/dist/index.js
+++ b/dist/index.js
@@ -18685,6 +18685,7 @@ const usePerBranchConfig = () => {
     const branchEntry = dict[context.BRANCH];
     if (!branchEntry) {
       core.info(`No config found for branch ${context.BRANCH}`);
+      return;
     }
 
     core.info(branchEntry);

--- a/dist/index.js
+++ b/dist/index.js
@@ -18688,7 +18688,7 @@ const usePerBranchConfig = () => {
       return;
     }
 
-    core.info(branchEntry);
+    core.info(JSON.stringify(branchEntry, null, 2));
     context.ALIAS_DOMAINS = branchEntry.aliases;
     context.PRODUCTION = branchEntry.production;
   } else {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "deploy-to-vercel-action",
-  "version": "1.9.13",
+  "version": "1.10",
   "description": "Deploy your project to Vercel using GitHub Actions. Supports PR previews and GitHub deployments.",
   "main": "dist/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "deploy-to-vercel-action",
-  "version": "1.10",
+  "version": "1.10.4",
   "description": "Deploy your project to Vercel using GitHub Actions. Supports PR previews and GitHub deployments.",
   "main": "dist/index.js",
   "scripts": {

--- a/src/config.js
+++ b/src/config.js
@@ -183,7 +183,6 @@ const usePerBranchConfig = () => {
     // using this to know if this is working
     core.warn("No PER_BRANCH_CONFIG found");
   }
-  context.ALIAS_DOMAINS;
 };
 
 setDynamicVars();

--- a/src/config.js
+++ b/src/config.js
@@ -179,6 +179,9 @@ const usePerBranchConfig = () => {
     core.info(branchEntry);
     context.ALIAS_DOMAINS = branchEntry.aliases;
     context.PRODUCTION = branchEntry.production;
+  } else {
+    // using this to know if this is working
+    core.warn("No PER_BRANCH_CONFIG found");
   }
   context.ALIAS_DOMAINS;
 };

--- a/src/config.js
+++ b/src/config.js
@@ -177,7 +177,7 @@ const usePerBranchConfig = () => {
       return;
     }
 
-    core.info(branchEntry);
+    core.info(JSON.stringify(branchEntry, null, 2));
     context.ALIAS_DOMAINS = branchEntry.aliases;
     context.PRODUCTION = branchEntry.production;
   } else {

--- a/src/config.js
+++ b/src/config.js
@@ -174,6 +174,7 @@ const usePerBranchConfig = () => {
     const branchEntry = dict[context.BRANCH];
     if (!branchEntry) {
       core.info(`No config found for branch ${context.BRANCH}`);
+      return;
     }
 
     core.info(branchEntry);

--- a/src/config.js
+++ b/src/config.js
@@ -1,156 +1,194 @@
-const core = require('@actions/core')
-const github = require('@actions/github')
-const parser = require('action-input-parser')
-require('dotenv').config()
+const core = require("@actions/core");
+const github = require("@actions/github");
+const parser = require("action-input-parser");
+require("dotenv").config();
 
-const IS_PR = [ 'pull_request', 'pull_request_target' ].includes(github.context.eventName)
+const IS_PR = ["pull_request", "pull_request_target"].includes(
+  github.context.eventName
+);
 
 const context = {
-	GITHUB_TOKEN: parser.getInput({
-		key: [ 'GH_PAT', 'GITHUB_TOKEN' ],
-		required: true
-	}),
-	VERCEL_TOKEN: parser.getInput({
-		key: 'VERCEL_TOKEN',
-		required: true
-	}),
-	VERCEL_ORG_ID: parser.getInput({
-		key: 'VERCEL_ORG_ID',
-		required: true
-	}),
-	VERCEL_PROJECT_ID: parser.getInput({
-		key: 'VERCEL_PROJECT_ID',
-		required: true
-	}),
-	PRODUCTION: parser.getInput({
-		key: 'PRODUCTION',
-		type: 'boolean',
-		default: !IS_PR
-	}),
-	GITHUB_DEPLOYMENT: parser.getInput({
-		key: 'GITHUB_DEPLOYMENT',
-		type: 'boolean',
-		default: true
-	}),
-	CREATE_COMMENT: parser.getInput({
-		key: 'CREATE_COMMENT',
-		type: 'boolean',
-		default: true
-	}),
-	DELETE_EXISTING_COMMENT: parser.getInput({
-		key: 'DELETE_EXISTING_COMMENT',
-		type: 'boolean',
-		default: true
-	}),
-	ATTACH_COMMIT_METADATA: parser.getInput({
-		key: 'ATTACH_COMMIT_METADATA',
-		type: 'boolean',
-		default: true
-	}),
-	DEPLOY_PR_FROM_FORK: parser.getInput({
-		key: 'DEPLOY_PR_FROM_FORK',
-		type: 'boolean',
-		default: false
-	}),
-	PR_LABELS: parser.getInput({
-		key: 'PR_LABELS',
-		default: [ 'deployed' ],
-		type: 'array',
-		disableable: true
-	}),
-	ALIAS_DOMAINS: parser.getInput({
-		key: 'ALIAS_DOMAINS',
-		type: 'array',
-		disableable: true
-	}),
-	PR_PREVIEW_DOMAIN: parser.getInput({
-		key: 'PR_PREVIEW_DOMAIN'
-	}),
-	VERCEL_SCOPE: parser.getInput({
-		key: 'VERCEL_SCOPE'
-	}),
-	GITHUB_REPOSITORY: parser.getInput({
-		key: 'GITHUB_REPOSITORY',
-		required: true
-	}),
-	GITHUB_DEPLOYMENT_ENV: parser.getInput({
-		key: 'GITHUB_DEPLOYMENT_ENV'
-	}),
-	TRIM_COMMIT_MESSAGE: parser.getInput({
-		key: 'TRIM_COMMIT_MESSAGE',
-		type: 'boolean',
-		default: false
-	}),
-	WORKING_DIRECTORY: parser.getInput({
-		key: 'WORKING_DIRECTORY'
-	}),
-	BUILD_ENV: parser.getInput({
-		key: 'BUILD_ENV',
-		type: 'array'
-	}),
-	PREBUILT: parser.getInput({
-		key: 'PREBUILT',
-		type: 'boolean',
-		default: false
-	}),
-	RUNNING_LOCAL: process.env.RUNNING_LOCAL === 'true',
-	FORCE: parser.getInput({
-		key: 'FORCE',
-		type: 'boolean',
-		default: false
-	})
-}
+  GITHUB_TOKEN: parser.getInput({
+    key: ["GH_PAT", "GITHUB_TOKEN"],
+    required: true,
+  }),
+  VERCEL_TOKEN: parser.getInput({
+    key: "VERCEL_TOKEN",
+    required: true,
+  }),
+  VERCEL_ORG_ID: parser.getInput({
+    key: "VERCEL_ORG_ID",
+    required: true,
+  }),
+  VERCEL_PROJECT_ID: parser.getInput({
+    key: "VERCEL_PROJECT_ID",
+    required: true,
+  }),
+  PRODUCTION: parser.getInput({
+    key: "PRODUCTION",
+    type: "boolean",
+    default: !IS_PR,
+  }),
+  GITHUB_DEPLOYMENT: parser.getInput({
+    key: "GITHUB_DEPLOYMENT",
+    type: "boolean",
+    default: true,
+  }),
+  CREATE_COMMENT: parser.getInput({
+    key: "CREATE_COMMENT",
+    type: "boolean",
+    default: true,
+  }),
+  DELETE_EXISTING_COMMENT: parser.getInput({
+    key: "DELETE_EXISTING_COMMENT",
+    type: "boolean",
+    default: true,
+  }),
+  ATTACH_COMMIT_METADATA: parser.getInput({
+    key: "ATTACH_COMMIT_METADATA",
+    type: "boolean",
+    default: true,
+  }),
+  DEPLOY_PR_FROM_FORK: parser.getInput({
+    key: "DEPLOY_PR_FROM_FORK",
+    type: "boolean",
+    default: false,
+  }),
+  PR_LABELS: parser.getInput({
+    key: "PR_LABELS",
+    default: ["deployed"],
+    type: "array",
+    disableable: true,
+  }),
+  ALIAS_DOMAINS: parser.getInput({
+    key: "ALIAS_DOMAINS",
+    type: "array",
+    disableable: true,
+  }),
+  PR_PREVIEW_DOMAIN: parser.getInput({
+    key: "PR_PREVIEW_DOMAIN",
+  }),
+  VERCEL_SCOPE: parser.getInput({
+    key: "VERCEL_SCOPE",
+  }),
+  GITHUB_REPOSITORY: parser.getInput({
+    key: "GITHUB_REPOSITORY",
+    required: true,
+  }),
+  GITHUB_DEPLOYMENT_ENV: parser.getInput({
+    key: "GITHUB_DEPLOYMENT_ENV",
+  }),
+  TRIM_COMMIT_MESSAGE: parser.getInput({
+    key: "TRIM_COMMIT_MESSAGE",
+    type: "boolean",
+    default: false,
+  }),
+  WORKING_DIRECTORY: parser.getInput({
+    key: "WORKING_DIRECTORY",
+  }),
+  BUILD_ENV: parser.getInput({
+    key: "BUILD_ENV",
+    type: "array",
+  }),
+  PREBUILT: parser.getInput({
+    key: "PREBUILT",
+    type: "boolean",
+    default: false,
+  }),
+  RUNNING_LOCAL: process.env.RUNNING_LOCAL === "true",
+  FORCE: parser.getInput({
+    key: "FORCE",
+    type: "boolean",
+    default: false,
+  }),
+
+  // Github actions do not support dictionaries. We have pass json strings
+  // https://github.com/argoproj/argo-workflows/issues/2077
+  PER_BRANCH_CONFIG: parser.getInput({
+    key: "PER_BRANCH_CONFIG",
+  }),
+};
 
 const setDynamicVars = () => {
-	context.USER = context.GITHUB_REPOSITORY.split('/')[0]
-	context.REPOSITORY = context.GITHUB_REPOSITORY.split('/')[1]
+  context.USER = context.GITHUB_REPOSITORY.split("/")[0];
+  context.REPOSITORY = context.GITHUB_REPOSITORY.split("/")[1];
 
-	// If running the action locally, use env vars instead of github.context
-	if (context.RUNNING_LOCAL) {
-		context.SHA = process.env.SHA || 'XXXXXXX'
-		context.IS_PR = process.env.IS_PR === 'true' || false
-		context.PR_NUMBER = process.env.PR_NUMBER || undefined
-		context.REF = process.env.REF || 'refs/heads/master'
-		context.BRANCH = process.env.BRANCH || 'master'
-		context.PRODUCTION = process.env.PRODUCTION === 'true' || !context.IS_PR
-		context.LOG_URL = process.env.LOG_URL || `https://github.com/${ context.USER }/${ context.REPOSITORY }`
-		context.ACTOR = process.env.ACTOR || context.USER
-		context.IS_FORK = process.env.IS_FORK === 'true' || false
-		context.TRIM_COMMIT_MESSAGE = process.env.TRIM_COMMIT_MESSAGE === 'true' || false
+  // If running the action locally, use env vars instead of github.context
+  if (context.RUNNING_LOCAL) {
+    context.SHA = process.env.SHA || "XXXXXXX";
+    context.IS_PR = process.env.IS_PR === "true" || false;
+    context.PR_NUMBER = process.env.PR_NUMBER || undefined;
+    context.REF = process.env.REF || "refs/heads/master";
+    context.BRANCH = process.env.BRANCH || "master";
+    context.PRODUCTION = process.env.PRODUCTION === "true" || !context.IS_PR;
+    context.LOG_URL =
+      process.env.LOG_URL ||
+      `https://github.com/${context.USER}/${context.REPOSITORY}`;
+    context.ACTOR = process.env.ACTOR || context.USER;
+    context.IS_FORK = process.env.IS_FORK === "true" || false;
+    context.TRIM_COMMIT_MESSAGE =
+      process.env.TRIM_COMMIT_MESSAGE === "true" || false;
 
-		return
-	}
+    return;
+  }
 
-	context.IS_PR = IS_PR
-	context.LOG_URL = `https://github.com/${ context.USER }/${ context.REPOSITORY }/actions/runs/${ process.env.GITHUB_RUN_ID }`
+  context.IS_PR = IS_PR;
+  context.LOG_URL = `https://github.com/${context.USER}/${context.REPOSITORY}/actions/runs/${process.env.GITHUB_RUN_ID}`;
 
-	// Use different values depending on if the Action was triggered by a PR
-	if (context.IS_PR) {
-		context.PR_NUMBER = github.context.payload.number
-		context.ACTOR = github.context.payload.pull_request.user.login
-		context.REF = github.context.payload.pull_request.head.ref
-		context.SHA = github.context.payload.pull_request.head.sha
-		context.BRANCH = github.context.payload.pull_request.head.ref
-		context.IS_FORK = github.context.payload.pull_request.head.repo.full_name !== context.GITHUB_REPOSITORY
-	} else {
-		context.ACTOR = github.context.actor
-		context.REF = github.context.ref
-		context.SHA = github.context.sha
-		context.BRANCH = github.context.ref.substr(11)
-	}
-}
+  // Use different values depending on if the Action was triggered by a PR
+  if (context.IS_PR) {
+    context.PR_NUMBER = github.context.payload.number;
+    context.ACTOR = github.context.payload.pull_request.user.login;
+    context.REF = github.context.payload.pull_request.head.ref;
+    context.SHA = github.context.payload.pull_request.head.sha;
+    context.BRANCH = github.context.payload.pull_request.head.ref;
+    context.IS_FORK =
+      github.context.payload.pull_request.head.repo.full_name !==
+      context.GITHUB_REPOSITORY;
+  } else {
+    context.ACTOR = github.context.actor;
+    context.REF = github.context.ref;
+    context.SHA = github.context.sha;
+    context.BRANCH = github.context.ref.substr(11);
+  }
+};
 
-setDynamicVars()
+const parseJsonAliasesDict = () => {
+  try {
+    return JSON.parse(context.PER_BRANCH_CONFIG);
+  } catch (err) {
+    core.setFailed("PER_BRANCH_CONFIG is not a valid JSON string");
+    throw err;
+  }
+};
 
-core.setSecret(context.GITHUB_TOKEN)
-core.setSecret(context.VERCEL_TOKEN)
+const usePerBranchConfig = () => {
+  if (context.PER_BRANCH_CONFIG) {
+    /**
+     * @typedef {{aliases: string[], production: boolean}} BranchEntry
+     */
+    /** @type Object.<string, BranchEntry> */
+    const dict = parseJsonAliasesDict();
+    core.info(`Using per-branch config for branch ${context.BRANCH}`);
 
-core.debug(
-	JSON.stringify(
-		context,
-		null,
-		2
-	)
-)
+    const branchEntry = dict[context.BRANCH];
+    if (!branchEntry) {
+      core.info(`No config found for branch ${context.BRANCH}`);
+    }
 
-module.exports = context
+    core.info(branchEntry);
+    context.ALIAS_DOMAINS = branchEntry.aliases;
+    context.PRODUCTION = branchEntry.production;
+  }
+  context.ALIAS_DOMAINS;
+};
+
+setDynamicVars();
+usePerBranchConfig();
+
+core.setSecret(context.GITHUB_TOKEN);
+core.setSecret(context.VERCEL_TOKEN);
+
+core.debug(JSON.stringify(context, null, 2));
+
+module.exports = context;

--- a/src/vercel.js
+++ b/src/vercel.js
@@ -1,119 +1,135 @@
-const core = require('@actions/core')
-const got = require('got')
-const { exec, removeSchema } = require('./helpers')
+const core = require("@actions/core");
+const got = require("got");
+const { exec, removeSchema } = require("./helpers");
 
 const {
-	VERCEL_TOKEN,
-	PRODUCTION,
-	VERCEL_SCOPE,
-	VERCEL_ORG_ID,
-	VERCEL_PROJECT_ID,
-	SHA,
-	USER,
-	REPOSITORY,
-	REF,
-	TRIM_COMMIT_MESSAGE,
-	BUILD_ENV,
-	PREBUILT,
-	WORKING_DIRECTORY,
-	FORCE
-} = require('./config')
+  VERCEL_TOKEN,
+  PRODUCTION,
+  VERCEL_SCOPE,
+  VERCEL_ORG_ID,
+  VERCEL_PROJECT_ID,
+  SHA,
+  USER,
+  REPOSITORY,
+  REF,
+  BRANCH,
+  TRIM_COMMIT_MESSAGE,
+  BUILD_ENV,
+  PREBUILT,
+  WORKING_DIRECTORY,
+  FORCE,
+} = require("./config");
 
 const init = () => {
-	core.info('Setting environment variables for Vercel CLI')
-	core.exportVariable('VERCEL_ORG_ID', VERCEL_ORG_ID)
-	core.exportVariable('VERCEL_PROJECT_ID', VERCEL_PROJECT_ID)
+  core.info(JSON.stringify({ REF, BRANCH, WORKING_DIRECTORY }, null, 2));
 
-	let deploymentUrl
+  core.info("Setting environment variables for Vercel CLI");
+  core.exportVariable("VERCEL_ORG_ID", VERCEL_ORG_ID);
+  core.exportVariable("VERCEL_PROJECT_ID", VERCEL_PROJECT_ID);
 
-	const deploy = async (commit) => {
-		let commandArguments = [ `--token=${ VERCEL_TOKEN }` ]
+  let deploymentUrl;
 
-		if (VERCEL_SCOPE) {
-			commandArguments.push(`--scope=${ VERCEL_SCOPE }`)
-		}
+  const deploy = async (commit) => {
+    let commandArguments = [`--token=${VERCEL_TOKEN}`];
 
-		if (PRODUCTION) {
-			commandArguments.push('--prod')
-		}
+    if (VERCEL_SCOPE) {
+      commandArguments.push(`--scope=${VERCEL_SCOPE}`);
+    }
 
-		if (PREBUILT) {
-			commandArguments.push('--prebuilt')
-		}
+    if (PRODUCTION) {
+      commandArguments.push("--prod");
+    }
 
-		if (FORCE) {
-			commandArguments.push('--force')
-		}
+    if (PREBUILT) {
+      commandArguments.push("--prebuilt");
+    }
 
-		if (commit) {
-			const metadata = [
-				`githubCommitAuthorName=${ commit.authorName }`,
-				`githubCommitAuthorLogin=${ commit.authorLogin }`,
-				`githubCommitMessage=${ TRIM_COMMIT_MESSAGE ? commit.commitMessage.split(/\r?\n/)[0] : commit.commitMessage }`,
-				`githubCommitOrg=${ USER }`,
-				`githubCommitRepo=${ REPOSITORY }`,
-				`githubCommitRef=${ REF }`,
-				`githubCommitSha=${ SHA }`,
-				`githubOrg=${ USER }`,
-				`githubRepo=${ REPOSITORY }`,
-				`githubDeployment=1`
-			]
+    if (FORCE) {
+      commandArguments.push("--force");
+    }
 
-			metadata.forEach((item) => {
-				commandArguments = commandArguments.concat([ '--meta', item ])
-			})
-		}
+    if (commit) {
+      const metadata = [
+        `githubCommitAuthorName=${commit.authorName}`,
+        `githubCommitAuthorLogin=${commit.authorLogin}`,
+        `githubCommitMessage=${
+          TRIM_COMMIT_MESSAGE
+            ? commit.commitMessage.split(/\r?\n/)[0]
+            : commit.commitMessage
+        }`,
+        `githubCommitOrg=${USER}`,
+        `githubCommitRepo=${REPOSITORY}`,
+        // We use the BRANCH here to allow Vercel to use the correct environment variables in each case.
+        // For example, if we wanted Vercel to match a variable to the "canary" environment, using `REF`
+        // would send "refs/heads/canary" as the value instead of "canary" (and only the latter would match the configuration)
+        `githubCommitRef=${BRANCH}`,
+        `githubCommitSha=${SHA}`,
+        `githubOrg=${USER}`,
+        `githubRepo=${REPOSITORY}`,
+        `githubDeployment=1`,
+      ];
 
-		if (BUILD_ENV) {
-			BUILD_ENV.forEach((item) => {
-				commandArguments = commandArguments.concat([ '--build-env', item ])
-			})
-		}
+      metadata.forEach((item) => {
+        commandArguments = commandArguments.concat(["--meta", item]);
+      });
+    }
 
-		core.info('Starting deploy with Vercel CLI')
-		const output = await exec('vercel', commandArguments, WORKING_DIRECTORY)
-		const parsed = output.match(/(?<=https?:\/\/)(.*)/g)[0]
+    if (BUILD_ENV) {
+      BUILD_ENV.forEach((item) => {
+        commandArguments = commandArguments.concat(["--build-env", item]);
+      });
+    }
 
-		if (!parsed) throw new Error('Could not parse deploymentUrl')
+    core.info("Starting deploy with Vercel CLI");
+    const output = await exec("vercel", commandArguments, WORKING_DIRECTORY);
+    const parsed = output.match(/(?<=https?:\/\/)(.*)/g)[0];
 
-		deploymentUrl = parsed
+    if (!parsed) throw new Error("Could not parse deploymentUrl");
 
-		return deploymentUrl
-	}
+    deploymentUrl = parsed;
 
-	const assignAlias = async (aliasUrl) => {
-		const commandArguments = [ `--token=${ VERCEL_TOKEN }`, 'alias', 'set', deploymentUrl, removeSchema(aliasUrl) ]
+    return deploymentUrl;
+  };
 
-		if (VERCEL_SCOPE) {
-			commandArguments.push(`--scope=${ VERCEL_SCOPE }`)
-		}
+  const assignAlias = async (aliasUrl) => {
+    const commandArguments = [
+      `--token=${VERCEL_TOKEN}`,
+      "alias",
+      "set",
+      deploymentUrl,
+      removeSchema(aliasUrl),
+    ];
 
-		const output = await exec('vercel', commandArguments, WORKING_DIRECTORY)
+    if (VERCEL_SCOPE) {
+      commandArguments.push(`--scope=${VERCEL_SCOPE}`);
+    }
 
-		return output
-	}
+    const output = await exec("vercel", commandArguments, WORKING_DIRECTORY);
 
-	const getDeployment = async () => {
-		const url = `https://api.vercel.com/v11/now/deployments/get?url=${ deploymentUrl }`
-		const options = {
-			headers: {
-				Authorization: `Bearer ${ VERCEL_TOKEN }`
-			}
-		}
+    return output;
+  };
 
-		const res = await got(url, options).json()
+  const getDeployment = async () => {
+    const url = `https://api.vercel.com/v11/now/deployments/get?url=${deploymentUrl}`;
+    const options = {
+      headers: {
+        Authorization: `Bearer ${VERCEL_TOKEN}`,
+      },
+    };
 
-		return res
-	}
+    const res = await got(url, options).json();
 
-	return {
-		deploy,
-		assignAlias,
-		deploymentUrl,
-		getDeployment
-	}
-}
+    return res;
+  };
+
+  return {
+    deploy,
+    assignAlias,
+    deploymentUrl,
+    getDeployment,
+  };
+};
 
 module.exports = {
-	init
-}
+  init,
+};


### PR DESCRIPTION
These changes are not currently going to be part of the `master` branch, since it will more maintainable to add this logic in our app and use the open source action as is.

This PR acts as documentation for the `feat/inhouse-1.10` branch which adds the following changes:

- [Feat: Per branch config](https://github.com/tianhuil/deploy-to-vercel-action/pull/1) (Feature that lets us pass a dictionary with per branch config)
- [Chore/bump-version](https://github.com/tianhuil/deploy-to-vercel-action/pull/2) (me trying to make this available but not realizing I have to run pnpm build)
- [Chore/build project](https://github.com/tianhuil/deploy-to-vercel-action/pull/3) (running pnpm build)
- [Fix: return on no entry](https://github.com/tianhuil/deploy-to-vercel-action/pull/4) (fix a bug)
- [Feat/pretty-print-json](https://github.com/tianhuil/deploy-to-vercel-action/pull/5) (add prints in order to debug what's happening in case something goes wrong)
- [Feat: Use branch instead of ref when pushing to Vercel](https://github.com/tianhuil/deploy-to-vercel-action/pull/6) (Make the action send the branch we triggered the build from to Vercel in a way they understand, in order to get proper Environment Variables, i.e. GIT_CRYPT_ENV correctly set up on canary vs staging vs production)