### PR TITLE
Feat/add option to compress files before uploading them to vercel

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,9 @@ Here are all the inputs [deploy-to-vercel-action](https://github.com/BetaHuhn/de
 | `WORKING_DIRECTORY` | Working directory for the Vercel CLI | **No** | N/A |
 | `FORCE` | Used to skip the build cache. | **No** | false
 | `PREBUILT` | Deploy a prebuilt Vercel Project. | **No** | false
-| `DEBUG` | Show debug information when executing Vercel commands. | **No** | false
+| `DEBUG` | Show debug information when executing Vercel commands. | **No** | false |
+| `VERCEL_ARCHIVE` | Value passed to the --archive vercel flag. Used to compress files before uploading to Vercel. | **No** | N/A |
+
 
 
 ## 🛠️ Configuration

--- a/action.yml
+++ b/action.yml
@@ -87,6 +87,10 @@ inputs:
     description: |
       Show debug information when executing Vercel commands.
     required: false
+  VERCEL_ARCHIVE:
+    description: |
+      Value passed to the --archive vercel flag. Used to compress files before uploading to Vercel.
+    required: false
 
 outputs:
   PREVIEW_URL:

--- a/dist/index.js
+++ b/dist/index.js
@@ -18614,6 +18614,9 @@ const context = {
 		key: 'DEBUG',
 		type: 'boolean',
 		default: false
+	}),
+	VERCEL_ARCHIVE: parser.getInput({
+		key: 'VERCEL_ARCHIVE'
 	})
 }
 
@@ -18882,7 +18885,8 @@ const {
 	PREBUILT,
 	WORKING_DIRECTORY,
 	FORCE,
-	DEBUG
+	DEBUG,
+	VERCEL_ARCHIVE
 } = __nccwpck_require__(9439)
 
 const init = () => {
@@ -18912,6 +18916,9 @@ const init = () => {
 		}
 		if (DEBUG) {
 			commandArguments.push('--debug')
+		}
+		if (VERCEL_ARCHIVE) {
+			commandArguments.push(`--archive=${ VERCEL_ARCHIVE }`)
 		}
 
 		if (commit) {

--- a/src/config.js
+++ b/src/config.js
@@ -103,6 +103,9 @@ const context = {
 		key: 'DEBUG',
 		type: 'boolean',
 		default: false
+	}),
+	VERCEL_ARCHIVE: parser.getInput({
+		key: 'VERCEL_ARCHIVE'
 	})
 }
 

--- a/src/vercel.js
+++ b/src/vercel.js
@@ -17,7 +17,8 @@ const {
 	PREBUILT,
 	WORKING_DIRECTORY,
 	FORCE,
-	DEBUG
+	DEBUG,
+	VERCEL_ARCHIVE
 } = require('./config')
 
 const init = () => {
@@ -47,6 +48,9 @@ const init = () => {
 		}
 		if (DEBUG) {
 			commandArguments.push('--debug')
+		}
+		if (VERCEL_ARCHIVE) {
+			commandArguments.push(`--archive=${ VERCEL_ARCHIVE }`)
 		}
 
 		if (commit) {


### PR DESCRIPTION
Allow passing the `--archive` option to the `vercel` command, in order to compress files.
This allows us to compress to tgz to speed up the upload and go over the 15000 files limit (https://github.com/orgs/vercel/discussions/1083#discussioncomment-6496761)