### PR TITLE
Feat: Run using Node 20

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -107,7 +107,7 @@ outputs:
     description: "The unique deployment url on Vercel"
 
 runs:
-  using: "node16"
+  using: "node20"
   main: "dist/index.js"
 
 branding:


### PR DESCRIPTION
Upgrade the action to use Node 20, as it was running on a deprecated Node version (Node 16)
