### PR TITLE
Fix: Undefined stdout should equal empty string

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -18836,7 +18836,8 @@ const execCmd = (command, args, cwd) => {
 		})
 
 		process.on('close', (code) => {
-			code !== 0 ? reject(new Error(stderr)) : resolve(stdout.trim())
+			const output = stdout === undefined ? '' : stdout
+			code !== 0 ? reject(new Error(stderr)) : resolve(output.trim())
 		})
 	})
 }

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -23,7 +23,8 @@ const execCmd = (command, args, cwd) => {
 		})
 
 		process.on('close', (code) => {
-			code !== 0 ? reject(new Error(stderr)) : resolve(stdout.trim())
+			const output = stdout === undefined ? '' : stdout
+			code !== 0 ? reject(new Error(stderr)) : resolve(output.trim())
 		})
 	})
 }


### PR DESCRIPTION
Fix https://github.com/BetaHuhn/deploy-to-vercel-action/issues/388 by treating an undefined stdout as an empty string